### PR TITLE
Fixes enableCustomListView being silently discarded when collectionOverrides.admin is set: admin is now destructured out of the wholesale override spread and merged key by key, with the components key computed after the user's admin. Adds a unit spec that fails 3/5 on the old code, and documents the option in the README's options block where it was missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ export type PayloadFeatureFlagsConfig = {
   disabled?: boolean
   
   /**
+   * Replace the feature flags collection's list view in the admin panel
+   * with the plugin's custom overview. Merges with any components set in
+   * collectionOverrides.admin.components.
+   * @default false
+   */
+  enableCustomListView?: boolean
+  
+  /**
    * Override collection configuration
    */
   collectionOverrides?: {

--- a/dev/plugin.spec.ts
+++ b/dev/plugin.spec.ts
@@ -1,0 +1,90 @@
+import type { Config } from 'payload'
+
+import { describe, expect, test } from 'vitest'
+
+import { payloadFeatureFlags } from '../src/index.js'
+
+const CUSTOM_LIST_VIEW = '@xtr-dev/payload-feature-flags/views#FeatureFlagsView'
+
+const applyPlugin = (options: Parameters<typeof payloadFeatureFlags>[0]) =>
+  payloadFeatureFlags(options)({ collections: [] } as unknown as Config)
+
+const featureFlagsCollection = (config: Config) =>
+  config.collections!.find((collection) => collection.slug === 'feature-flags')!
+
+describe('enableCustomListView', () => {
+  test('registers the custom list view when no collectionOverrides are given', () => {
+    const config = applyPlugin({ enableCustomListView: true })
+
+    const collection = featureFlagsCollection(config)
+    expect(collection.admin?.components?.views?.list).toEqual({
+      Component: CUSTOM_LIST_VIEW,
+    })
+  })
+
+  test('survives collectionOverrides.admin.components and keeps the override', () => {
+    const config = applyPlugin({
+      enableCustomListView: true,
+      collectionOverrides: {
+        admin: {
+          components: {
+            beforeList: ['./Foo'],
+          },
+        },
+      },
+    })
+
+    const components = featureFlagsCollection(config).admin?.components
+    expect(components?.beforeList).toEqual(['./Foo'])
+    expect(components?.views?.list).toEqual({ Component: CUSTOM_LIST_VIEW })
+  })
+
+  test('survives collectionOverrides.admin that sets unrelated admin keys', () => {
+    const config = applyPlugin({
+      enableCustomListView: true,
+      collectionOverrides: {
+        admin: {
+          group: 'Custom Group',
+        },
+      },
+    })
+
+    const admin = featureFlagsCollection(config).admin
+    expect(admin?.group).toBe('Custom Group')
+    expect(admin?.components?.views?.list).toEqual({ Component: CUSTOM_LIST_VIEW })
+  })
+
+  test('leaves the user components untouched when disabled', () => {
+    const config = applyPlugin({
+      enableCustomListView: false,
+      collectionOverrides: {
+        admin: {
+          components: {
+            beforeList: ['./Foo'],
+          },
+        },
+      },
+    })
+
+    const components = featureFlagsCollection(config).admin?.components
+    expect(components?.beforeList).toEqual(['./Foo'])
+    expect(components?.views?.list).toBeUndefined()
+  })
+
+  test('user admin overrides still replace the plugin defaults', () => {
+    const config = applyPlugin({
+      collectionOverrides: {
+        admin: {
+          useAsTitle: 'description',
+          description: 'Custom description',
+        },
+      },
+    })
+
+    const admin = featureFlagsCollection(config).admin
+    expect(admin?.useAsTitle).toBe('description')
+    expect(admin?.description).toBe('Custom description')
+    // Defaults the user did not touch stay in place
+    expect(admin?.group).toBe('Configuration')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,8 +159,11 @@ export const payloadFeatureFlags =
       ? collectionOverrides.fields({ defaultFields })
       : defaultFields
 
-    // Extract field overrides from collectionOverrides
-    const { fields: _fieldsOverride, ...otherOverrides } = collectionOverrides || {}
+    // Extract field and admin overrides from collectionOverrides. Admin must be
+    // merged key by key rather than spread wholesale: a blanket spread of the
+    // user's admin object (whether here or via otherOverrides below) replaces the
+    // components key and silently discards enableCustomListView.
+    const { fields: _fieldsOverride, admin: adminOverride, ...otherOverrides } = collectionOverrides || {}
 
     // Create the feature flags collection with overrides
     const featureFlagsCollection: CollectionConfig = {
@@ -169,16 +172,16 @@ export const payloadFeatureFlags =
         useAsTitle: 'name',
         group: 'Configuration',
         description: 'Manage feature flags for your application',
+        ...(adminOverride || {}),
         components: enableCustomListView ? {
-          ...collectionOverrides?.admin?.components,
+          ...adminOverride?.components,
           views: {
-            ...collectionOverrides?.admin?.components?.views,
+            ...adminOverride?.components?.views,
             list: {
               Component: '@xtr-dev/payload-feature-flags/views#FeatureFlagsView'
             }
           }
-        } : collectionOverrides?.admin?.components || {},
-        ...(collectionOverrides?.admin || {}),
+        } : adminOverride?.components || {},
       },
       fields,
       // Apply any other collection overrides


### PR DESCRIPTION
The plugin builds its feature-flags collection by layering user overrides over defaults, and `enableCustomListView` — which injects the plugin's custom list view into `admin.components.views.list` — was being dropped whenever the user also passed `collectionOverrides.admin`. The issue diagnosed one clobber: inside the admin object, `...(collectionOverrides?.admin || {})` was spread AFTER the carefully merged `components` key, replacing it whenever the user's admin had a `components` key of its own.

Implementing the issue's proposed reorder alone turned out to be insufficient, though: there is a second, wholesale clobber one level up. `...otherOverrides` at the end of the collection literal spreads everything from `collectionOverrides` except `fields` — including `admin` — so any user-supplied admin object replaced the entire built admin, custom list view and all, regardless of the inner spread order. The issue's own proposed test (enableCustomListView: true plus admin.components.beforeList) still failed with only the reorder applied. So the fix destructures `admin` out of `otherOverrides` alongside `fields`, and builds the admin object as: plugin defaults, then the user's admin spread over them (so useAsTitle/group/description overrides still win), then `components` computed last as the merge of the user's components with the plugin's list view. A comment on the destructure records why admin cannot be spread wholesale. The access invariant is untouched — `access` still flows through `...otherOverrides` unchanged.

The new spec is a plain vitest unit file in dev/. The plugin factory is a pure synchronous function over a config object, so no Payload/database boot is needed — deliberately unlike dev/int.spec.ts, which boots a full instance (and which is unmodified payload-plugin-template boilerplate that fails for unrelated reasons; I left it alone as separate work). Five cases: the view registers with no overrides; it survives admin.components (the issue's exact test — beforeList kept AND views.list set); it survives unrelated admin keys (group); enableCustomListView: false passes user components through untouched with no list view injected; and user admin overrides still beat plugin defaults while untouched defaults remain. Verified the spec catches the bug by stashing the src change: 3 of 5 fail on the old code, all pass on the new. `tsc --noEmit` is clean; eslint's config ignores both src/index.ts and dev specs (pre-existing).

README: added `enableCustomListView` to the Configuration Options type block, matching the other options' JSDoc style, and noting it merges with `collectionOverrides.admin.components` since that interaction is exactly what was broken.