### PR TITLE
Update Claude Code workflows to claude-code-action v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,76 +3,63 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      - 'src/**'
+      - 'dev/**'
+      - 'package.json'
+      - 'tsconfig.json'
+      - '.github/workflows/**'
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    if: |
+      !contains(github.event.pull_request.title, '[skip-review]') &&
+      !contains(github.event.pull_request.title, '[WIP]')
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-    
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Posts the review through a tracking comment on the PR
+          track_progress: true
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
+          # Reuse one comment instead of adding a new one on every push
+          use_sticky_comment: true
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          prompt: |
+            Review this pull request to the @xtr-dev/payload-feature-flags
+            Payload CMS v3 plugin and give feedback on:
+            - Correctness of the plugin config, collection schema and server hooks
+              (`src/index.ts`, `src/hooks/server.ts`)
+            - Payload v3 API usage and plugin conventions, including
+              `collectionOverrides` and access control
+            - Type safety and the public export surface (main, `rsc`, `client`)
+            - Backwards compatibility for existing consumers of the published package
+            - Potential bugs, performance issues and security concerns
+            - Test coverage for new behaviour
 
+            Be constructive and concrete: point at files and lines, and skip
+            nitpicks that a linter would already catch.
+
+          claude_args: |
+            --max-turns 15
+            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,46 +19,36 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read # Lets Claude read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
 
+          claude_args: |
+            --max-turns 20
+            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm build:*),Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm dev:generate-types)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-feature-flags",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Feature flags plugin for Payload CMS - manage feature toggles, A/B tests, and gradual rollouts",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Both Claude workflows were still the original scaffold, pinned to `anthropics/claude-code-action@beta` and passing inputs that v1 removed (`direct_prompt` in particular), so the review workflow would no longer run as written.

## Changes

**`.github/workflows/claude.yml`** (@claude mentions)
- Pinned to `anthropics/claude-code-action@v1`
- Turn and tool limits moved into `claude_args` (`--max-turns`, `--allowedTools`), allowlisting this repo's own pnpm scripts (install, build, lint, test, generate-types)
- Permissions widened to `contents`/`pull-requests`/`issues: write`, which v1 needs to post comments and push branches
- Added pnpm + Node 20 setup with cache so Claude can actually run those builds and lint
- `actions/checkout` bumped to v5

**`.github/workflows/claude-code-review.yml`** (automatic PR review)
- Pinned to `@v1`; `direct_prompt` replaced with `prompt` plus `track_progress: true`, which is how v1 drives automatic reviews on `pull_request` events
- `use_sticky_comment: true` so subsequent pushes update one comment instead of stacking new ones
- Review prompt tailored to this plugin: plugin config and server hooks, Payload v3 conventions and `collectionOverrides`, the public export surface (main/rsc/client), and backwards compatibility for published-package consumers
- Scoped to `src/**`, `dev/**`, `package.json`, `tsconfig.json` and workflow files
- Skips PRs titled `[WIP]` or `[skip-review]`, and a concurrency group cancels superseded runs on rapid pushes

The large commented-out template blocks were dropped from both files.

## Notes

- Both workflows keep using the existing `CLAUDE_CODE_OAUTH_TOKEN` secret — no new secrets required.
- No model is pinned, so the action's default is used rather than a version that goes stale.
- `pr-version-check.yml` and `version-and-publish.yml` are untouched.

All four workflow files were verified to parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfxrvHNc4VYDxeeUGzqHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAfxrvHNc4VYDxeeUGzqHU)_