### PR TITLE
Fixes CLAUDE.md's stale claim that the dev/test harness uses MongoDB Memory Server — it has run on @payloadcms/db-sqlite for some time, and since CLAUDE.md loads into every agent session, the old claim actively misdirects debugging.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The plugin creates a feature flags collection with these key fields:
 - `metadata`: Additional JSON data
 
 ### Development Environment
-- Uses MongoDB Memory Server for testing
+- Uses @payloadcms/db-sqlite for testing
 - Next.js for admin panel development
 - SWC for fast compilation
 - Vitest for integration testing
@@ -99,7 +99,7 @@ The plugin integrates with Payload by:
 
 ### Testing Setup
 The development configuration (`dev/payload.config.ts`) includes:
-- MongoDB Memory Server for isolated testing
+- @payloadcms/db-sqlite for isolated testing
 - Test collections (posts, media)
 - Example plugin configuration with collection overrides
 - Seeding functionality for development data


### PR DESCRIPTION
CLAUDE.md described the plugin's development/testing environment as using "MongoDB Memory Server" in two places (Development Environment and Testing Setup sections). That's no longer accurate: dev/payload.config.ts imports `sqliteAdapter` from `@payloadcms/db-sqlite` and configures it as the db (`db: sqliteAdapter({...})`, pointing at `file:./dev.db`). No source file in the repo imports `mongodb-memory-server` — it remains listed in devDependencies but is unused.

This change corrects both CLAUDE.md lines to say the dev/test setup uses `@payloadcms/db-sqlite` instead of MongoDB Memory Server. Scope is deliberately limited to the two false documentation lines. The unused devDependencies (mongodb-memory-server, @payloadcms/db-mongodb, @payloadcms/db-postgres) are left untouched here — that cleanup touches the lockfile and is already covered by a separate branch (chore/remove-unused-devdeps), so bundling it in would duplicate review surface for no reason.