### PR TITLE
Corrects the Try the Demo and demo README so they describe the SQLite file database the harness actually starts, instead of an in-memory MongoDB that this repo never launches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ pnpm dev
 ```
 
 **What you get:**
-- 🗃️ **No database needed** - Uses in-memory MongoDB
+- 🗃️ **No database server needed** - Uses SQLite at `file:./dev.db`
 - 🎯 **Sample data included** - Ready-to-test feature flag
 - 🔑 **Auto-login** - Use `dev@payloadcms.com / test`
 - 📱 **Working dashboard** - See flags in action

--- a/dev/README.md
+++ b/dev/README.md
@@ -63,7 +63,7 @@ curl 'http://localhost:3000/api/feature-flags?where[enabled][equals]=true'
 
 ## Database
 
-Uses in-memory MongoDB - no setup needed! Data resets on each restart.
+Uses SQLite at `file:./dev.db` (or `DATABASE_URI`). No database server to start; data persists across restarts.
 
 ## Creating New Flags
 
@@ -84,7 +84,7 @@ Ready to use this in your project?
 
 1. **Add to your project:** Copy the plugin config
 2. **Customize:** Add your own fields and permissions  
-3. **Go live:** Use a real MongoDB database
+3. **Go live:** Use your production Payload database adapter
 4. **Monitor:** Track how your flags perform
 
 ---


### PR DESCRIPTION
The development harness in `dev/payload.config.ts` uses `sqliteAdapter` from `@payloadcms/db-sqlite` with `url: process.env.DATABASE_URI || 'file:./dev.db'`. Nothing in the repo starts `mongodb-memory-server`. CLAUDE.md already names sqlite (merged as 0ea17d4 / PR #21); the two READMEs were the leftover.

The root README's Try the Demo list still said "No database needed — Uses in-memory MongoDB". That is now "No database server needed — Uses SQLite at `file:./dev.db`", which matches the default adapter URL. The Features-list line about trying the demo with no database setup is unchanged: sqlite still needs no server, and that sentence never named MongoDB.

`dev/README.md` had two related errors. The Database section claimed in-memory MongoDB and that data resets on each restart; the sqlite file persists (and is gitignored as `/dev.db`), so both the engine name and the reset claim were wrong. It now names `file:./dev.db` and `DATABASE_URI`, and says data persists. The Next Steps "Go live" line told operators to use a real MongoDB; the plugin stores flags in whatever adapter the host Payload app already uses, so that step now says to use the production Payload database adapter rather than MongoDB specifically.

This does not remove the unused `mongodb-memory-server` / `@payloadcms/db-mongodb` / `@payloadcms/db-postgres` packages or the `serverExternalPackages` entry in `dev/next.config.mjs`. That cleanup already lives on `chore/remove-unused-devdeps` and does not touch either README.