### PR TITLE
Points `pnpm test` at `vitest run` so CI actually executes the suite instead of `exit 0`, excludes the Playwright spec from Vitest, and replaces the template integration tests with ones that exercise this plugin against sqlite.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This is a Payload CMS v3 plugin for feature flags (@xtr-dev/payload-feature-flag
 - `pnpm copyfiles` - Copy non-TS assets to dist
 
 ### Testing & Quality
-- `pnpm test` - Run all tests (integration + e2e)
+- `pnpm test` - Run the integration tests (alias for `pnpm test:int`; e2e is separate because Playwright needs installed browsers)
 - `pnpm test:int` - Run integration tests with Vitest
 - `pnpm test:e2e` - Run end-to-end tests with Playwright
 - `pnpm lint` - Run ESLint

--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -6,30 +6,98 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 let payload: Payload
 
-afterAll(async () => {
-  await payload.destroy()
-})
-
 beforeAll(async () => {
   payload = await getPayload({ config })
 })
 
-describe('Plugin integration tests', () => {
-  test('can create post with custom text field added by plugin', async () => {
-    const post = await payload.create({
-      collection: 'posts',
-      data: {
-        addedByPlugin: 'added by plugin',
-      },
-    })
-    expect(post.addedByPlugin).toBe('added by plugin')
+afterAll(async () => {
+  await payload.destroy()
+})
+
+describe('feature flags plugin', () => {
+  test('registers the feature-flags collection', () => {
+    expect(payload.collections['feature-flags']).toBeDefined()
   })
 
-  test('plugin creates and seeds plugin-collection', async () => {
-    expect(payload.collections['plugin-collection']).toBeDefined()
+  test('collection carries the plugin fields and the override fields together', () => {
+    const fieldNames = payload.collections['feature-flags'].config.fields
+      .map((field) => ('name' in field ? field.name : null))
+      .filter(Boolean)
 
-    const { docs } = await payload.find({ collection: 'plugin-collection' })
+    // Plugin defaults, with rollouts and variants enabled in dev/payload.config.ts
+    expect(fieldNames).toEqual(
+      expect.arrayContaining([
+        'name',
+        'description',
+        'enabled',
+        'rolloutPercentage',
+        'variants',
+        'tags',
+        'metadata',
+      ]),
+    )
+    // Fields added through collectionOverrides.fields must survive alongside the defaults
+    expect(fieldNames).toEqual(
+      expect.arrayContaining(['environment', 'owner', 'expiresAt', 'jiraTicket']),
+    )
+  })
+
+  test('the seeded flag is readable back from the database', async () => {
+    const { docs } = await payload.find({
+      collection: 'feature-flags',
+      where: { name: { equals: 'new-feature' } },
+    })
 
     expect(docs).toHaveLength(1)
+    expect(docs[0].enabled).toBe(true)
+    expect(docs[0].environment).toBe('development')
+  })
+
+  test('a flag with rollout and variants round-trips through a real adapter', async () => {
+    // Unique per run: the sqlite file persists between local runs and `name` is unique
+    const name = `int-test-${Date.now()}`
+
+    const created = await payload.create({
+      collection: 'feature-flags',
+      data: {
+        name,
+        description: 'created by dev/int.spec.ts',
+        enabled: true,
+        environment: 'staging',
+        rolloutPercentage: 25,
+        variants: [
+          { name: 'control', weight: 50 },
+          { name: 'variant-a', weight: 50 },
+        ],
+      },
+    })
+
+    const found = await payload.findByID({
+      collection: 'feature-flags',
+      id: created.id,
+    })
+
+    expect(found.name).toBe(name)
+    expect(found.enabled).toBe(true)
+    expect(found.environment).toBe('staging')
+    expect(found.rolloutPercentage).toBe(25)
+    expect(found.variants).toHaveLength(2)
+    expect(found.variants[0].name).toBe('control')
+    expect(found.variants[0].weight).toBe(50)
+
+    await payload.delete({ collection: 'feature-flags', id: created.id })
+  })
+
+  test('the unique constraint on name reaches the adapter', async () => {
+    await expect(
+      payload.create({
+        collection: 'feature-flags',
+        data: {
+          name: 'new-feature', // already created by the seed
+          enabled: false,
+          environment: 'development',
+        },
+      }),
+    ).rejects.toThrow()
   })
 })

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "lint": "eslint",
     "lint:fix": "eslint ./src --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "exit 0",
+    "test": "pnpm test:int",
     "test:e2e": "playwright test",
-    "test:int": "vitest"
+    "test:int": "vitest run"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,7 +2,7 @@ import path from 'path'
 import { loadEnv } from 'payload/node'
 import { fileURLToPath } from 'url'
 import tsconfigPaths from 'vite-tsconfig-paths'
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -18,6 +18,9 @@ export default defineConfig(() => {
     ],
     test: {
       environment: 'node',
+      // e2e.spec.ts is a Playwright suite (run by `pnpm test:e2e`); vitest's default
+      // include of *.spec.ts would load it and fail on Playwright's test() guard
+      exclude: [...configDefaults.exclude, '**/e2e.spec.ts'],
       hookTimeout: 30_000,
       testTimeout: 30_000,
     },


### PR DESCRIPTION
The publish workflow's only test step is `pnpm test`. That script has been `exit 0` since the suite was temporarily disabled for CI, so a green check on main has meant nothing ran. The real Vitest entry was `pnpm test:int`, and that was bare `vitest`, which is watch mode and would hang if CI had invoked it.

`test` now aliases `test:int`, and `test:int` is `vitest run` so the process exits. Two further changes are required for that to stay green: vitest's default `*.spec.ts` include would load `dev/e2e.spec.ts`, where Playwright's `test()` throws outside its own runner, so that file is excluded (Playwright stays on `pnpm test:e2e`); and the previous `dev/int.spec.ts` was leftover plugin-template boilerplate asserting a `posts.addedByPlugin` field and a `plugin-collection` this plugin does not create. It now checks collection registration, default plus override fields, the seeded `new-feature` flag, a rollout/variants round-trip, and the unique name constraint against the sqlite adapter.

Wiring the advertised script also runs the unit specs already on main (`dev/collection-fields.spec.ts`, `dev/plugin.spec.ts`). Changing only the two script strings was considered and rejected: watch mode would hang CI, and the e2e include plus the template spec would fail it.

Verified locally with `pnpm test` twice: 18 tests, 3 files, all passing; e2e.spec.ts is not collected.