### PR TITLE
Remove max-turns argument from code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,5 +61,4 @@ jobs:
             nitpicks that a linter would already catch.
 
           claude_args: |
-            --max-turns 15
             --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*)"


### PR DESCRIPTION
Removed the max-turns argument from claude_args.