### PR TITLE
RSC feature-flag hooks return the seven collection schema fields and map Payload's omitted optional values from null to undefined, so the published FeatureFlag type matches runtime.

### DIFF
--- a/dev/server-hooks.spec.ts
+++ b/dev/server-hooks.spec.ts
@@ -21,6 +21,14 @@ const completeFlag = {
   metadata: { owner: 'growth' },
 }
 
+const storedCompleteFlag = {
+  ...completeFlag,
+  id: 'flag-1',
+  createdAt: '2026-08-23T00:00:00.000Z',
+  updatedAt: '2026-08-23T00:00:00.000Z',
+  environment: 'production',
+}
+
 const makePayload = (docs: Array<typeof completeFlag | Record<string, unknown>>): Payload =>
   ({
     config: {
@@ -54,13 +62,13 @@ const makePayload = (docs: Array<typeof completeFlag | Record<string, unknown>>)
 
 describe('RSC feature flag mappers', () => {
   test('getFeatureFlag returns description and tags with the rest of the flag', async () => {
-    const payload = makePayload([completeFlag])
+    const payload = makePayload([storedCompleteFlag])
 
     await expect(getFeatureFlag('new-homepage', payload)).resolves.toEqual(completeFlag)
   })
 
   test('getAllFeatureFlags returns description and tags for each active flag', async () => {
-    const payload = makePayload([completeFlag])
+    const payload = makePayload([storedCompleteFlag])
 
     await expect(getAllFeatureFlags(payload)).resolves.toEqual({
       'new-homepage': completeFlag,
@@ -68,7 +76,7 @@ describe('RSC feature flag mappers', () => {
   })
 
   test('getFeatureFlagsByTag returns description and tags for matching flags', async () => {
-    const payload = makePayload([completeFlag])
+    const payload = makePayload([storedCompleteFlag])
 
     await expect(getFeatureFlagsByTag('homepage', payload)).resolves.toEqual([completeFlag])
   })

--- a/dev/server-hooks.spec.ts
+++ b/dev/server-hooks.spec.ts
@@ -1,0 +1,81 @@
+import type { Payload } from 'payload'
+
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  getAllFeatureFlags,
+  getFeatureFlag,
+  getFeatureFlagsByTag,
+} from '../src/hooks/server.js'
+
+const completeFlag = {
+  name: 'new-homepage',
+  description: 'Shows the redesigned homepage',
+  enabled: true,
+  rolloutPercentage: 50,
+  variants: [
+    { name: 'control', weight: 50 },
+    { name: 'variant-a', weight: 50 },
+  ],
+  tags: [{ tag: 'homepage' }, { tag: 'experiment' }],
+  metadata: { owner: 'growth' },
+}
+
+const makePayload = (docs: Array<typeof completeFlag | Record<string, unknown>>): Payload =>
+  ({
+    config: {
+      collections: [
+        {
+          slug: 'feature-flags',
+          fields: [
+            { name: 'name', type: 'text', unique: true },
+            { name: 'enabled', type: 'checkbox' },
+          ],
+        },
+      ],
+    },
+    find: vi.fn(async ({ where }: { where?: Record<string, { equals?: unknown }> }) => {
+      let filtered = docs
+      if (where?.name?.equals !== undefined) {
+        filtered = filtered.filter((doc) => doc.name === where.name.equals)
+      }
+      if (where?.enabled?.equals !== undefined) {
+        filtered = filtered.filter((doc) => doc.enabled === where.enabled.equals)
+      }
+      if (where?.['tags.tag']?.equals !== undefined) {
+        const tag = where['tags.tag'].equals
+        filtered = filtered.filter((doc) =>
+          Array.isArray(doc.tags) && doc.tags.some((entry: { tag?: string }) => entry.tag === tag),
+        )
+      }
+      return { docs: filtered }
+    }),
+  }) as unknown as Payload
+
+describe('RSC feature flag mappers', () => {
+  test('getFeatureFlag returns description and tags with the rest of the flag', async () => {
+    const payload = makePayload([completeFlag])
+
+    await expect(getFeatureFlag('new-homepage', payload)).resolves.toEqual(completeFlag)
+  })
+
+  test('getAllFeatureFlags returns description and tags for each active flag', async () => {
+    const payload = makePayload([completeFlag])
+
+    await expect(getAllFeatureFlags(payload)).resolves.toEqual({
+      'new-homepage': completeFlag,
+    })
+  })
+
+  test('getFeatureFlagsByTag returns description and tags for matching flags', async () => {
+    const payload = makePayload([completeFlag])
+
+    await expect(getFeatureFlagsByTag('homepage', payload)).resolves.toEqual([completeFlag])
+  })
+
+  test('getFeatureFlag returns null when the name does not exist', async () => {
+    const payload = makePayload([])
+
+    await expect(getFeatureFlag('missing-flag', payload)).resolves.toBeNull()
+  })
+})

--- a/dev/server-hooks.spec.ts
+++ b/dev/server-hooks.spec.ts
@@ -29,6 +29,42 @@ const storedCompleteFlag = {
   environment: 'production',
 }
 
+const sparseFlag = {
+  name: 'sparse-flag',
+  enabled: true,
+}
+
+const storedSparseFlag = {
+  name: 'sparse-flag',
+  description: null,
+  enabled: true,
+  rolloutPercentage: null,
+  variants: null,
+  tags: null,
+  metadata: null,
+  id: 'flag-2',
+  createdAt: '2026-08-23T00:00:00.000Z',
+  updatedAt: '2026-08-23T00:00:00.000Z',
+  environment: 'production',
+}
+
+const storedFlagWithNullableNestedFields = {
+  name: 'nullable-nested',
+  description: null,
+  enabled: true,
+  rolloutPercentage: null,
+  variants: [{ name: 'control', weight: 100, metadata: null, id: 'v1' }],
+  tags: [
+    { tag: null, id: 't1' },
+    { tag: 'homepage', id: 't2' },
+  ],
+  metadata: null,
+  id: 'flag-3',
+  createdAt: '2026-08-23T00:00:00.000Z',
+  updatedAt: '2026-08-23T00:00:00.000Z',
+  environment: 'production',
+}
+
 const makePayload = (docs: Array<typeof completeFlag | Record<string, unknown>>): Payload =>
   ({
     config: {
@@ -85,5 +121,37 @@ describe('RSC feature flag mappers', () => {
     const payload = makePayload([])
 
     await expect(getFeatureFlag('missing-flag', payload)).resolves.toBeNull()
+  })
+
+  test('getFeatureFlag maps omitted optional Payload fields to undefined', async () => {
+    const payload = makePayload([storedSparseFlag])
+    const flag = await getFeatureFlag('sparse-flag', payload)
+
+    expect(flag).toEqual(sparseFlag)
+    expect(flag?.description).toBeUndefined()
+    expect(flag?.rolloutPercentage).toBeUndefined()
+    expect(flag?.variants).toBeUndefined()
+    expect(flag?.tags).toBeUndefined()
+    expect(flag?.metadata).toBeUndefined()
+  })
+
+  test('getAllFeatureFlags maps omitted optional Payload fields to undefined', async () => {
+    const payload = makePayload([storedSparseFlag])
+    const flags = await getAllFeatureFlags(payload)
+
+    expect(flags).toEqual({ 'sparse-flag': sparseFlag })
+    expect(flags['sparse-flag']?.description).toBeUndefined()
+    expect(flags['sparse-flag']?.tags).toBeUndefined()
+  })
+
+  test('getFeatureFlag keeps string tags and drops null nested Payload fields', async () => {
+    const payload = makePayload([storedFlagWithNullableNestedFields])
+
+    await expect(getFeatureFlag('nullable-nested', payload)).resolves.toEqual({
+      name: 'nullable-nested',
+      enabled: true,
+      variants: [{ name: 'control', weight: 100 }],
+      tags: [{ tag: 'homepage' }],
+    })
   })
 })

--- a/src/hooks/server.ts
+++ b/src/hooks/server.ts
@@ -15,15 +15,7 @@ export interface FeatureFlag {
   metadata?: any
 }
 
-function toFeatureFlag(doc: {
-  name: unknown
-  enabled: unknown
-  description?: unknown
-  rolloutPercentage?: unknown
-  variants?: unknown
-  tags?: unknown
-  metadata?: unknown
-}): FeatureFlag {
+function toFeatureFlag(doc: Record<string, unknown>): FeatureFlag {
   return {
     name: doc.name as string,
     description: doc.description as string | undefined,

--- a/src/hooks/server.ts
+++ b/src/hooks/server.ts
@@ -3,6 +3,7 @@ import { cache } from "react"
 
 export interface FeatureFlag {
   name: string
+  description?: string
   enabled: boolean
   rolloutPercentage?: number
   variants?: Array<{
@@ -10,7 +11,28 @@ export interface FeatureFlag {
     weight: number
     metadata?: any
   }>
+  tags?: Array<{ tag: string }>
   metadata?: any
+}
+
+function toFeatureFlag(doc: {
+  name: unknown
+  enabled: unknown
+  description?: unknown
+  rolloutPercentage?: unknown
+  variants?: unknown
+  tags?: unknown
+  metadata?: unknown
+}): FeatureFlag {
+  return {
+    name: doc.name as string,
+    description: doc.description as string | undefined,
+    enabled: doc.enabled as boolean,
+    rolloutPercentage: doc.rolloutPercentage as number | undefined,
+    variants: doc.variants as FeatureFlag['variants'],
+    tags: doc.tags as FeatureFlag['tags'],
+    metadata: doc.metadata,
+  }
 }
 
 // Helper to get the collection slug from config
@@ -52,15 +74,7 @@ export const getFeatureFlag = cache(async (flagName: string, payload: Payload): 
       return null
     }
 
-    const flag = result.docs[0]
-
-    return {
-      name: flag.name as string,
-      enabled: flag.enabled as boolean,
-      rolloutPercentage: flag.rolloutPercentage as number | undefined,
-      variants: flag.variants as any,
-      metadata: flag.metadata,
-    }
+    return toFeatureFlag(result.docs[0])
   } catch (error) {
     console.error(`Failed to fetch feature flag ${flagName}:`, error)
     return null
@@ -95,13 +109,7 @@ export const getAllFeatureFlags = cache(async (payload: Payload): Promise<Record
     const flags: Record<string, FeatureFlag> = {}
 
     for (const doc of result.docs) {
-      flags[doc.name as string] = {
-        name: doc.name as string,
-        enabled: doc.enabled as boolean,
-        rolloutPercentage: doc.rolloutPercentage as number | undefined,
-        variants: doc.variants as any,
-        metadata: doc.metadata,
-      }
+      flags[doc.name as string] = toFeatureFlag(doc)
     }
 
     return flags
@@ -186,13 +194,7 @@ export const getFeatureFlagsByTag = cache(async (tag: string, payload: Payload):
       limit: 1000,
     })
 
-    return result.docs.map(doc => ({
-      name: doc.name as string,
-      enabled: doc.enabled as boolean,
-      rolloutPercentage: doc.rolloutPercentage as number | undefined,
-      variants: doc.variants as any,
-      metadata: doc.metadata,
-    }))
+    return result.docs.map(doc => toFeatureFlag(doc))
   } catch (error) {
     console.error(`Failed to fetch feature flags with tag ${tag}:`, error)
     return []

--- a/src/hooks/server.ts
+++ b/src/hooks/server.ts
@@ -15,15 +15,50 @@ export interface FeatureFlag {
   metadata?: any
 }
 
+// Payload returns omitted optional fields as null; FeatureFlag advertises them as optional (`?:`).
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
+  return value ?? undefined
+}
+
+function mapVariants(value: unknown): FeatureFlag['variants'] {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  return value.map((entry) => {
+    const variant = (entry ?? {}) as Record<string, unknown>
+    return {
+      name: variant.name as string,
+      weight: variant.weight as number,
+      metadata: nullToUndefined(variant.metadata),
+    }
+  })
+}
+
+function mapTags(value: unknown): FeatureFlag['tags'] {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const tags: Array<{ tag: string }> = []
+  for (const entry of value) {
+    const tag = entry && typeof entry === 'object' ? (entry as Record<string, unknown>).tag : undefined
+    if (typeof tag === 'string') {
+      tags.push({ tag })
+    }
+  }
+  return tags
+}
+
 function toFeatureFlag(doc: Record<string, unknown>): FeatureFlag {
   return {
     name: doc.name as string,
-    description: doc.description as string | undefined,
+    description: nullToUndefined(doc.description as string | null | undefined),
     enabled: doc.enabled as boolean,
-    rolloutPercentage: doc.rolloutPercentage as number | undefined,
-    variants: doc.variants as FeatureFlag['variants'],
-    tags: doc.tags as FeatureFlag['tags'],
-    metadata: doc.metadata,
+    rolloutPercentage: nullToUndefined(doc.rolloutPercentage as number | null | undefined),
+    variants: mapVariants(doc.variants),
+    tags: mapTags(doc.tags),
+    metadata: nullToUndefined(doc.metadata),
   }
 }
 


### PR DESCRIPTION
getFeatureFlag, getAllFeatureFlags, and getFeatureFlagsByTag used to rebuild a five-field object and drop description and tags even though the collection defines them and the RSC FeatureFlag type advertised them. One mapper now returns the seven collection schema fields (name, description, enabled, rolloutPercentage, variants, tags, metadata) and drops document id, timestamps, and the demo-only environment field.

Payload stores untouched optional fields as null (description?: string | null in the generated types). The first mapper assigned those values through casts, so a consumer of description?: string could observe null at runtime. The mapper now converts omitted optional fields to undefined, keeps tag: string by dropping rows whose tag is not a string, and strips nested variant/tag row ids. Widening the public type to include null was rejected: the RSC contract is a mapped shape, not a Payload document dump.

The spec covers the populated seven-field document, a stored document whose optional fields are absent (null from Payload), and nested null tag/variant fields. pnpm build and the server-hooks spec pass. Unrelated existing integration/e2e failures on main are unchanged.