### PR TITLE
Documents the published `/client` React API in the README so the eight named exports match the barrel, and shows `withFeatureFlag` as a curried wrap so `FallbackComponent` is the disabled fallback, not the wrappee.

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,32 @@ import { payloadFeatureFlags } from '@xtr-dev/payload-feature-flags'
 - `payloadFeatureFlags`: Main plugin configuration function
 - `PayloadFeatureFlagsConfig`: TypeScript type for configuration options
 
+### Client React API
+
+Import React hooks and the component-gating HOC from the `/client` entry point:
+
+```typescript
+import {
+  useFeatureFlags,
+  useFeatureFlag,
+  useSpecificFeatureFlag,
+  useVariantSelection,
+  useRolloutCheck,
+  withFeatureFlag,
+  type FeatureFlag,
+  type FeatureFlagOptions,
+} from '@xtr-dev/payload-feature-flags/client'
+```
+
+- `useFeatureFlags(initialFlags, options?)` - Fetch feature flags, returning `flags`, `loading`, `error`, and `refetch`.
+- `useFeatureFlag(flagName, options?)` - Check whether one flag is enabled, returning `isEnabled`, `flag`, `loading`, and `error`.
+- `useSpecificFeatureFlag(flagName, options?)` - Fetch one complete flag, returning `flag`, `loading`, `error`, and `refetch`.
+- `useVariantSelection(flagName, userId, options?)` - Select a stable variant for a user, returning `variant`, `flag`, `loading`, and `error`.
+- `useRolloutCheck(flagName, userId, options?)` - Check whether a user is in a flag's rollout, returning `isInRollout`, `flag`, `loading`, and `error`.
+- `withFeatureFlag(flagName, FallbackComponent?, options?)` - Higher-order component that renders its wrapped component only when the flag is enabled.
+- `FeatureFlag` - Type describing a flag's name, enabled state, rollout percentage, variants, and metadata.
+- `FeatureFlagOptions` - Optional client configuration: `serverURL`, `apiPath`, and `collectionSlug`.
+
 ### Server Component Hooks (RSC Export)
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ import {
 - `useSpecificFeatureFlag(flagName, options?)` - Fetch one complete flag, returning `flag`, `loading`, `error`, and `refetch`.
 - `useVariantSelection(flagName, userId, options?)` - Select a stable variant for a user, returning `variant`, `flag`, `loading`, and `error`.
 - `useRolloutCheck(flagName, userId, options?)` - Check whether a user is in a flag's rollout, returning `isInRollout`, `flag`, `loading`, and `error`.
-- `withFeatureFlag(flagName, FallbackComponent?, options?)` - Higher-order component that renders its wrapped component only when the flag is enabled.
+- `withFeatureFlag(flagName, FallbackComponent?, options?)(WrappedComponent)` - Higher-order component that renders `WrappedComponent` when the flag is enabled, and `FallbackComponent` when it is not.
 - `FeatureFlag` - Type describing a flag's name, enabled state, rollout percentage, variants, and metadata.
 - `FeatureFlagOptions` - Optional client configuration: `serverURL`, `apiPath`, and `collectionSlug`.
 


### PR DESCRIPTION
The package already publishes `@xtr-dev/payload-feature-flags/client` from `src/exports/client.ts`, which re-exports five hooks, `withFeatureFlag`, and the `FeatureFlag` / `FeatureFlagOptions` types. The README API Reference only named the main plugin export and the `/rsc` hooks, so a consumer following the docs would not find the client entry.

This change adds that inventory. Hook argument order and return fields match the implementations: `useFeatureFlags` is the one with `refetch` and a required `initialFlags`; `useFeatureFlag` is the enabled check without `refetch`; `useSpecificFeatureFlag` is the complete-flag fetch. `FeatureFlag` lists name, enabled, rolloutPercentage, variants, and metadata. `FeatureFlagOptions` lists `serverURL`, `apiPath`, and `collectionSlug`.

`withFeatureFlag` is curried — `withFeatureFlag(flagName, FallbackComponent?, options?)` returns a function that takes `WrappedComponent`. Documenting only the inner call made the fallback look like the wrappee, so a reader who wrote `export default withFeatureFlag('new-feature', MyPage)` would pass `MyPage` as the disabled fallback and get a function back. The signature now shows the wrap.

The section does not retell that these hooks `fetch` the collection REST API (they inherit its access rules, already stated under Security Considerations), and it does not add the required `payload` argument to the older RSC bullets.