### PR TITLE
Make the Claude workflows able to build, test and comment inline

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/**'
       - 'dev/**'
@@ -21,6 +21,7 @@ jobs:
       !contains(github.event.pull_request.title, '[WIP]')
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -31,7 +32,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          # Full history so Claude can diff the PR against its base branch
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      # The review allowlist includes lint/build/test, which need node_modules:
+      # the runner has no network for Claude, so install here instead. A
+      # lockfile drift should downgrade the review, not fail the workflow.
+      - name: Install dependencies
+        continue-on-error: true
+        run: pnpm install --frozen-lockfile
 
       - name: Run Claude Code Review
         id: claude-review
@@ -46,6 +64,9 @@ jobs:
           use_sticky_comment: true
 
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request to the @xtr-dev/payload-feature-flags
             Payload CMS v3 plugin and give feedback on:
             - Correctness of the plugin config, collection schema and server hooks
@@ -57,8 +78,17 @@ jobs:
             - Potential bugs, performance issues and security concerns
             - Test coverage for new behaviour
 
-            Be constructive and concrete: point at files and lines, and skip
-            nitpicks that a linter would already catch.
+            The PR branch is checked out and `pnpm install` has already run, so
+            `pnpm lint`, `pnpm test:int` and `pnpm build` are available - run the
+            ones that are relevant to the change rather than reasoning about the
+            diff alone. There is no network access, so do not try to install
+            anything new.
+
+            Be constructive and concrete: use
+            `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for issues tied to a specific line, keep the
+            summary in the tracking comment, and skip nitpicks that a linter
+            would already catch.
 
           claude_args: |
-            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm build:*),Bash(pnpm lint:*),Bash(pnpm test:*),Bash(pnpm dev:generate-types),Bash(npx tsc:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -28,7 +29,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          # Full history so Claude can diff against the base branch
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -38,6 +40,12 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+
+      # Claude has no network access, so dependencies have to be in place
+      # before it starts. A lockfile drift should not fail the whole run.
+      - name: Install dependencies
+        continue-on-error: true
+        run: pnpm install --frozen-lockfile
 
       - name: Run Claude Code
         id: claude
@@ -50,5 +58,4 @@ jobs:
             actions: read
 
           claude_args: |
-            --max-turns 20
-            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm build:*),Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm dev:generate-types)"
+            --allowedTools "Bash(pnpm install:*),Bash(pnpm build:*),Bash(pnpm lint:*),Bash(pnpm test:*),Bash(pnpm dev:generate-types),Bash(npx tsc:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-feature-flags",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Feature flags plugin for Payload CMS - manage feature toggles, A/B tests, and gradual rollouts",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Both Claude workflows are on `@v1` now, but they still promise Claude a toolchain that isn't there.

## What was actually broken

**The review job never sets up Node or pnpm and never installs dependencies.** It allowlists `pnpm install`, `pnpm build`, `pnpm lint`, `pnpm test`, but `pnpm` isn't on the runner and there is no network inside the action. The last green review ([run 32665909355](https://github.com/xtr-dev/payload-feature-flags/actions/runs/32665909355)) said so in its own comment on #25:

> `node_modules` isn't installed in this sandbox and network access for `pnpm install`/fetch is blocked, so I could not independently run `pnpm build` or `pnpm test:int`

That run reported `permission_denials_count: 6` — every review so far has been a static read of the diff.

**Allowlist entries were exact matches.** `Bash(pnpm install)` does not permit `pnpm install --frozen-lockfile`; `Bash(pnpm build)` does not permit `pnpm build:types`.

**The prompt asked for line-level feedback with no way to give it.** `mcp__github_inline_comment__create_inline_comment` was not allowlisted, so "point at files and lines" collapsed into one summary comment.

**`fetch-depth: 1`** leaves no base commit, so any `git diff` against the base branch fails.

**`--max-turns 20`** in the mention workflow is the same failure mode that killed the review workflow before ca28c09 removed its limit — [run 32663621521](https://github.com/xtr-dev/payload-feature-flags/actions/runs/32663621521) failed with `Reached maximum number of turns (15)`.

## Changes

- Set up pnpm + Node and run `pnpm install --frozen-lockfile` before the action in both workflows. The install is `continue-on-error` so a lockfile drift degrades the run instead of failing it.
- Widen allowlist entries to prefix patterns (`pnpm install:*`, `build:*`, `lint:*`, `test:*`) and add `npx tsc`, `git diff/log/show/status`.
- Allow the inline comment tool in the review and instruct Claude to use it with `confirmed: true`.
- Add `REPO`/`PR NUMBER` to the review prompt (per the action's own docs) and state that dependencies are installed and the network is closed, so Claude runs the checks instead of reasoning about the diff alone.
- `fetch-depth: 0` in both workflows.
- Drop `--max-turns 20` from the mention workflow.
- Add job timeouts (30m review, 60m mention) and `reopened`/`ready_for_review` review triggers.

## Verification

- Both files parse as YAML.
- `pnpm install --frozen-lockfile` succeeds against the committed `pnpm-lock.yaml` (21s), so the new install step will not stall the workflows.
- Version bumped to 0.0.22 — PR Version Check requires an increment on every PR to main.

The real check is the review workflow running on this PR: it should now install dependencies and be able to execute the repo's scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf4bDsXjf93HmS776docMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf4bDsXjf93HmS776docMJ)_