### PR TITLE
Keeps the editor-facing `enableCustomListView` documentation aligned with the README by warning that `collectionOverrides.admin.components` takes precedence when both options are configured.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ export type PayloadFeatureFlagsConfig = {
   /**
    * Enable the enhanced feature flags list view in the admin panel
    * @default false
+   * Note: if collectionOverrides.admin.components is also set, that value
+   * wins and this enhanced list view is silently dropped — see below.
    */
   enableCustomListView?: boolean
   

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add @xtr-dev/payload-feature-flags
 
 ## Requirements
 
-- Payload CMS v3.37.0+
+- Payload CMS v3.56.0+
 - Node.js 18.20.2+ or 20.9.0+
 - React 19.1.0+
 
@@ -80,6 +80,12 @@ export type PayloadFeatureFlagsConfig = {
    * @default true
    */
   enableVariants?: boolean
+
+  /**
+   * Enable the enhanced feature flags list view in the admin panel
+   * @default false
+   */
+  enableCustomListView?: boolean
   
   /**
    * Disable the plugin while keeping the database schema intact
@@ -617,12 +623,12 @@ import {
 ### Common Issues
 
 **Plugin not loading:**
-- Ensure Payload CMS v3.37.0+ is installed
+- Ensure Payload CMS v3.56.0+ is installed
 - Check that the plugin is properly added to the `plugins` array in your Payload config
 
 **Feature flags not appearing:**
-- Verify that collections are specified in the plugin configuration
 - Check that the plugin is not disabled (`disabled: false`)
+- Check that `collectionOverrides.access` allows the current user to read the feature flags collection
 
 **TypeScript errors:**
 - Ensure all peer dependencies are installed

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ export type PayloadFeatureFlagsConfig = {
    * Enable the enhanced feature flags list view in the admin panel
    * @default false
    * Note: if collectionOverrides.admin.components is also set, that value
-   * wins and this enhanced list view is silently dropped — see below.
+   * wins and this enhanced list view is silently dropped — see "Note on
+   * admin.components" under Custom Fields and Access.
    */
   enableCustomListView?: boolean
   
@@ -163,6 +164,23 @@ payloadFeatureFlags({
     },
   },
 })
+```
+
+**Note on `admin.components`:** If you set `collectionOverrides.admin.components`, it replaces the whole components object the plugin builds internally — including the list view injected by `enableCustomListView` — rather than merging with it. Setting `admin.components` to anything, even `{}`, silently drops the enhanced list view. If you need both, re-add the list view yourself:
+
+```typescript
+collectionOverrides: {
+  admin: {
+    components: {
+      views: {
+        list: {
+          Component: '@xtr-dev/payload-feature-flags/views#FeatureFlagsView',
+        },
+        // ...your other custom views
+      },
+    },
+  },
+},
 ```
 
 ### Security Considerations

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export type PayloadFeatureFlagsConfig = {
   collectionOverrides?: CollectionOverrides
   /**
    * Enable custom list view for feature flags
+   * Note: collectionOverrides.admin.components takes precedence when both are set.
    * @default false
    */
   enableCustomListView?: boolean


### PR DESCRIPTION
The README already documented the interaction between `enableCustomListView` and `collectionOverrides.admin.components`, but the exported configuration type’s JSDoc did not. This follow-up adds the same precedence warning at the source definition so developers see it in IDE hover information and the public documentation copies no longer disagree.