### PR TITLE
Fixes README's flag-checking samples so they match the shipped code: RSC samples/API reference now pass the required `payload` argument, and the three Advanced Usage fetches now use the working `?where[name][equals]=` query instead of a detail-by-id route the plugin never registers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ The custom view provides a more user-friendly interface compared to the standard
 The plugin provides server-side hooks for React Server Components:
 
 ```tsx
+import { getPayload } from 'payload'
+import config from '@payload-config'
 import { 
   isFeatureEnabled, 
   getFeatureFlag,
@@ -261,21 +263,24 @@ import {
 
 // Simple feature check
 export default async function HomePage() {
-  const showNewDesign = await isFeatureEnabled('new-homepage-design')
+  const payload = await getPayload({ config })
+  const showNewDesign = await isFeatureEnabled('new-homepage-design', payload)
   
   return showNewDesign ? <NewHomePage /> : <LegacyHomePage />
 }
 
 // Percentage-based rollout
 export default async function Dashboard({ userId }: { userId: string }) {
-  const inRollout = await isUserInRollout('beta-dashboard', userId)
+  const payload = await getPayload({ config })
+  const inRollout = await isUserInRollout('beta-dashboard', userId, payload)
   
   return inRollout ? <BetaDashboard /> : <ClassicDashboard />
 }
 
 // A/B testing with variants
 export default async function ProductPage({ userId }: { userId: string }) {
-  const variant = await getUserVariant('product-page-test', userId)
+  const payload = await getPayload({ config })
+  const variant = await getUserVariant('product-page-test', userId, payload)
   
   switch(variant) {
     case 'layout-a':
@@ -419,10 +424,10 @@ The plugin creates a collection with the following fields:
 // Example: Check feature flag from your frontend
 async function checkFeature(flagName: string): Promise<boolean> {
   try {
-    const response = await fetch(`/api/feature-flags/${flagName}`)
+    const response = await fetch(`/api/feature-flags?where[name][equals]=${flagName}`)
     if (!response.ok) return false
-    const flag = await response.json()
-    return flag.enabled
+    const result = await response.json()
+    return result.docs[0]?.enabled ?? false
   } catch {
     return false // Default to disabled on error
   }
@@ -450,8 +455,9 @@ function isUserInRollout(userId: string, percentage: number): boolean {
 }
 
 // Check if user should see the feature
-const flag = await fetch('/api/feature-flags/new-feature').then(r => r.json())
-if (flag.enabled && isUserInRollout(userId, flag.rolloutPercentage)) {
+const result = await fetch('/api/feature-flags?where[name][equals]=new-feature').then(r => r.json())
+const flag = result.docs[0]
+if (flag?.enabled && isUserInRollout(userId, flag.rolloutPercentage)) {
   // Show feature to this user
 }
 ```
@@ -479,8 +485,9 @@ function selectVariant(userId: string, variants: Array<{name: string, weight: nu
 }
 
 // Usage
-const flag = await fetch('/api/feature-flags/homepage-test').then(r => r.json())
-if (flag.enabled && flag.variants) {
+const result = await fetch('/api/feature-flags?where[name][equals]=homepage-test').then(r => r.json())
+const flag = result.docs[0]
+if (flag?.enabled && flag.variants) {
   const variant = selectVariant(userId, flag.variants)
   // Render based on variant
 }
@@ -603,14 +610,16 @@ import {
 } from '@xtr-dev/payload-feature-flags/rsc'
 ```
 
+All of these take a `payload: Payload` instance as their final argument (obtained via `await getPayload({ config })` — see the RSC example above).
+
 #### Available Functions:
 
-- `getFeatureFlag(flagName: string)` - Get complete flag data
-- `isFeatureEnabled(flagName: string)` - Simple boolean check
-- `getAllFeatureFlags()` - Get all active flags
-- `isUserInRollout(flagName: string, userId: string)` - Check rollout percentage
-- `getUserVariant(flagName: string, userId: string)` - Get A/B test variant
-- `getFeatureFlagsByTag(tag: string)` - Get flags by tag
+- `getFeatureFlag(flagName: string, payload: Payload)` - Get complete flag data
+- `isFeatureEnabled(flagName: string, payload: Payload)` - Simple boolean check
+- `getAllFeatureFlags(payload: Payload)` - Get all active flags
+- `isUserInRollout(flagName: string, userId: string, payload: Payload)` - Check rollout percentage
+- `getUserVariant(flagName: string, userId: string, payload: Payload)` - Get A/B test variant
+- `getFeatureFlagsByTag(tag: string, payload: Payload)` - Get flags by tag
 
 ## Troubleshooting
 


### PR DESCRIPTION
The README had two families of copy-pasteable flag-checking code, and neither worked against the published plugin — both failed silently to `false`/`undefined` rather than erroring, which is the worst possible failure mode for a getting-started sample: a user following the docs gets a feature that never turns on and nothing pointing at the docs as the cause.

**1. Missing `payload` argument (RSC samples + API reference).** Every hook in `src/hooks/server.ts` — `getFeatureFlag`, `isFeatureEnabled`, `getAllFeatureFlags`, `isUserInRollout`, `getUserVariant`, `getFeatureFlagsByTag` — takes a trailing `payload: Payload` argument. The README's "Using Feature Flags in React Server Components" samples and the six signatures under "Server Component Hooks (RSC Export)" in the API Reference called/documented all of them without it. In plain JS this runs, `payload` is `undefined`, `payload.find` throws inside the hook, and the hook's own catch block logs and returns `null`/`false` — so the sample "works" and just always says the flag is off.

Fixed by adding `import { getPayload } from 'payload'` / `import config from '@payload-config'` and `const payload = await getPayload({ config })` to each RSC sample (this is the exact pattern already used correctly in `dev/app/(app)/page.tsx`), threading `payload` through as the final argument to each hook call, and adding `payload: Payload` to all six documented signatures plus a one-line pointer back to the `getPayload` pattern.

**2. Wrong REST route (Advanced Usage fetches).** Three samples — "Conditional Feature Rendering", "Implementing Gradual Rollouts", "A/B Testing with Variants" — fetched `/api/feature-flags/${flagName}` (or a literal flag name) and read fields directly off the response body. The plugin registers no custom endpoints (`src/index.ts` only ever initialises `config.endpoints = []` and never pushes to it), so callers get Payload's standard REST API, whose detail route is `/api/{collection}/{id}` keyed by document id — not name. A name 404s, and each sample's `if (!response.ok) return false` / equivalent silently reports the flag as off. The README's own "Using Feature Flags via REST API" section (a few dozen lines earlier) already shows the correct form: `?where[name][equals]=...` reading from `result.docs[0]`.

Fixed by rewriting all three fetches to that same query form and response shape, so they're now consistent with the rest of the README instead of contradicting it.

Nothing outside README.md changed — this is docs-only, matching the issue's scope. I verified both defects directly against the current source (`src/hooks/server.ts` signatures, and `src/index.ts`'s endpoint registration) before making any edit, rather than trusting the issue text at face value.